### PR TITLE
Modernise img2fmem

### DIFF
--- a/img2fmem/README.md
+++ b/img2fmem/README.md
@@ -82,8 +82,6 @@ The [ImagePalette interface isn't well documented](https://pillow.readthedocs.io
 
 ## Usage Notes
 
-If you want the best quality colour conversion with few colours, use a package like GIMP or Photoshop to reduce the colours to 16 or 64 before using this tool. Just make sure the file format you save in has at least 256 colours.
-
 * If the value of `colour_bits` isn't valid it defaults to `8`
 * If the value of `palette_bits` isn't valid it defaults to `12`
 * img2fmem does not resize images: use your image editor to do this

--- a/img2fmem/README.md
+++ b/img2fmem/README.md
@@ -15,8 +15,10 @@ Licensed under the MIT License. See the [LICENSE](../LICENSE) file for details.
 
 ## Changes in 2025 Version
 
-* Use palette API rather than hacking low-level data structure, which no longer works in recent Pillow
+* Use palette API rather than hacking low-level data structure
+* Format image output in lines to match original image
 * Generate more compact output for 16 colour images
+* Always set `memory_initialization_radix` to 16 (it's hex format)
 * Use new-style format string f"{foo:02X}"
 
 ## Changes in 2020 Version

--- a/img2fmem/README.md
+++ b/img2fmem/README.md
@@ -78,8 +78,6 @@ For an image called `acme.tiff` that you want converted to 8-bit colour with 24-
 * Source images must be RGB rather than RGBA format. If you use RGBA then you'll probably end up with a screen of one solid colour. The `file(1)` command will tell you if you're using RGB or RGBA.
 * Images with transparency (such as PNGs) may produce colour artifacts or fail with a message about not being iterable. Save your image without transparency and all should be well.
 
-The [ImagePalette interface isn't well documented](https://pillow.readthedocs.io/en/stable/reference/ImagePalette.html). This script was written by looking at the Pillow source code, so isn't guaranteed to work with newer versions, but then again the palette code doesn't seem to have changed since 2001.
-
 ## Usage Notes
 
 * If the value of `colour_bits` isn't valid it defaults to `8`

--- a/img2fmem/README.md
+++ b/img2fmem/README.md
@@ -38,7 +38,11 @@ source ./fpgatools-venv/bin/activate
 pip install pillow
 ```
 
-After this initial install, you need to remember to source the environment before running img2fmem.py with `source ./fpgatools-venv/bin/activate`. 
+After this initial install, you need to remember to source the environment before running img2fmem.py with:
+
+```shell
+source ./fpgatools-venv/bin/activate
+```
 
 See official [Pillow Installation](https://pillow.readthedocs.io/en/stable/installation.html) instructions for more information.
 

--- a/img2fmem/README.md
+++ b/img2fmem/README.md
@@ -13,6 +13,12 @@ Example projects using this tool:
 
 Licensed under the MIT License. See the [LICENSE](../LICENSE) file for details.
 
+## Changes in 2025 Version
+
+* Use palette API rather than hacking low-level data structure, which no longer works in recent Pillow
+* Generate more compact output for 16 colour images
+* Use new-style format string f"{foo:02X}"
+
 ## Changes in 2020 Version
 
 * Adds support for 24-bit palettes (16.7 million colours), but retains a default of 12-bit palettes (4,096 colours).
@@ -21,13 +27,22 @@ Licensed under the MIT License. See the [LICENSE](../LICENSE) file for details.
 
 ## Install Pillow
 
-Install Pillow using **one** of the following methods:
+I recommend installing Pillow using pip within a Python venv; for example:
 
-* Debian/Ubuntu: `apt install python3-pil`
-* Use `pip3` to install package `pillow`
-* Or follow [Pillow Installation](https://pillow.readthedocs.io/en/stable/installation.html)
+```shell
+cd fpgatools
+python3 -m venv fpgatools-venv
+source ./fpgatools-venv/bin/activate
+pip install pillow
+```
+
+After this initial install, you need to remember to source the environment before running img2fmem.py with `source ./fpgatools-venv/bin/activate`. 
+
+See official [Pillow Installation](https://pillow.readthedocs.io/en/stable/installation.html) instructions for more information.
 
 ## Usage
+
+_Don't forget to source the Python venv if you installed Pillow that way (see above)._
 
 * To use run: `img2fmem.py image_file colour_bits output_format palette_bits`
 * Input Arguments

--- a/img2fmem/README.md
+++ b/img2fmem/README.md
@@ -17,7 +17,7 @@ Licensed under the MIT License. See the [LICENSE](../LICENSE) file for details.
 
 * Use palette API rather than hacking low-level data structure (hacking no longer works in newer Pillow anyway)
 * Format image output in lines to match original image for more manageable files
-* Generate more compact output for 16 colour images
+* Generate more compact output for 16-colour output (one hex value)
 * Always set `memory_initialization_radix` to 16 (it's hex format)
 * Use new-style Python format string `f"{foo:02X}"`
 

--- a/img2fmem/README.md
+++ b/img2fmem/README.md
@@ -99,13 +99,15 @@ If you're having issues:
 
 The palette is of the form `0xRRGGBB` (24-bit) or `0xRGB` (12-bit). Red is stored in the most-significant byte or nibble, then green, then blue.
 
-For example, for a 12-bit palette value the following SystemVerilog is correct:
+For example, for a 12-bit palette value use the following Verilog:
 
-    always_comb begin
-        red = palette[11:8];
-        green = palette[7:4];
-        blue = palette[3:0];
-    end
+```verilog
+always @(*) begin
+    red = palette[11:8];
+    green = palette[7:4];
+    blue = palette[3:0];
+end
+```
 
 If you're still having difficulties, try [simple.png](img2fmem/test/simple.png): it's a 64x64 image with simple, bright, colours.
 

--- a/img2fmem/README.md
+++ b/img2fmem/README.md
@@ -19,7 +19,7 @@ Licensed under the MIT License. See the [LICENSE](../LICENSE) file for details.
 * Format image output in lines to match original image
 * Generate more compact output for 16 colour images
 * Always set `memory_initialization_radix` to 16 (it's hex format)
-* Use new-style format string f"{foo:02X}"
+* Use new-style format string `f"{foo:02X}"`
 
 ## Changes in 2020 Version
 

--- a/img2fmem/README.md
+++ b/img2fmem/README.md
@@ -15,11 +15,11 @@ Licensed under the MIT License. See the [LICENSE](../LICENSE) file for details.
 
 ## Changes in 2025 Version
 
-* Use palette API rather than hacking low-level data structure
-* Format image output in lines to match original image
+* Use palette API rather than hacking low-level data structure (hacking no longer works in newer Pillow anyway)
+* Format image output in lines to match original image for more manageable files
 * Generate more compact output for 16 colour images
 * Always set `memory_initialization_radix` to 16 (it's hex format)
-* Use new-style format string `f"{foo:02X}"`
+* Use new-style Python format string `f"{foo:02X}"`
 
 ## Changes in 2020 Version
 

--- a/img2fmem/img2fmem.py
+++ b/img2fmem/img2fmem.py
@@ -53,23 +53,35 @@ dest_pal = dest_img.getpalette()
 # Generate hex image output
 image_data = dest_img.getdata()
 image_output = ''
+width_cnt = 0
 if output_format == 'mem':
     image_output += "// " + MESSAGE
     for d in image_data:
         if pal_size == 16:  # only one hex digit needed
-            image_output += f"{d:01X}\n"
+            image_output += f"{d:01X}"
         else:
-            image_output += f"{d:02X}\n"
+            image_output += f"{d:02X}"
+        if (width_cnt == width - 1):
+            image_output += "\n"
+            width_cnt = 0
+        else:
+            image_output += " "
+            width_cnt = width_cnt + 1
 elif output_format == 'coe':
     image_output += "; " + MESSAGE
-    image_output += f"memory_initialization_radix={colour_bits};\n"
+    image_output += f"memory_initialization_radix=16;\n"  # hex format
     image_output += "memory_initialization_vector=\n"
     for d in image_data:
         if pal_size == 16:
-            image_output += f"{d:01X},\n"
+            image_output += f"{d:01X},"
         else:
-            image_output += f"{d:02X},\n"
-
+            image_output += f"{d:02X},"
+        if (width_cnt == width - 1):
+            image_output += "\n"
+            width_cnt = 0
+        else:
+            image_output += " "
+            width_cnt = width_cnt + 1
     # replace last comma with semicolon to complete coe statement
     image_output = image_output[:-2]
     image_output += ";\n"
@@ -98,7 +110,7 @@ if output_format == 'mem':
     palette_output += "\n"
 elif output_format == 'coe':
     palette_output += "; " + MESSAGE
-    palette_output += f"memory_initialization_radix={palette_bits};\n"
+    palette_output += f"memory_initialization_radix=16;\n"
     palette_output += "memory_initialization_vector="
     for i in range(0, len(dest_pal), 3):
         r, g, b = dest_pal[i], dest_pal[i+1], dest_pal[i+2]


### PR DESCRIPTION
* Use palette API rather than hacking low-level data structure
* Format image output in lines to match original image
* Generate more compact output for 16 colour images
* Always set `memory_initialization_radix` to 16 (it's hex format)
* Use new-style format string `f"{foo:02X}"`